### PR TITLE
[Bugfix] Fix inconsistent drying

### DIFF
--- a/src/main/java/cool/bot/dewdropfarmland/block/CustomFarmland.java
+++ b/src/main/java/cool/bot/dewdropfarmland/block/CustomFarmland.java
@@ -65,7 +65,7 @@ public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource
         }
         long dayTime = level.getDayTime() % 24000;
         // check before rain
-        if (dayTime >= Config.dailyTimeMin && dayTime <= Config.dailyTimeMin + 10) {
+        if (dayTime >= Config.dailyTimeMin && dayTime < Config.dailyTimeMin + 10) {
             if (!Util.isMoistWaterable(level, pos)) {
                 if (RNG.mc_ihundo(random, Config.dailyDecayChance)) {
                     level.setBlock(pos, Blocks.DIRT.defaultBlockState(), 3);


### PR DESCRIPTION
Hi! I was working on my fork of the mod when I noticed some crops were randomly drying even when watered. 

I tested this in the base mod using `/time set 23900`. Once the time hits `24000` the drying logic will double run depending on which tick the farmland is on.

Figured out it was because `dayTime >= Config.dailyTimeMin && dayTime < Config.dailyTimeMin + 10` logically has `11` ticks total where it evaluates to true. So if it runs on the first tick, it'll run again in 10 ticks.

Tested this new logic a few times and this fixes the issue.